### PR TITLE
prefix all the glog flags with `tt_`

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -396,12 +396,12 @@ type flushSyncWriter interface {
 }
 
 func init() {
-	flag.BoolVar(&logging.toStderr, "logtostderr", false, "log to standard error instead of files")
-	flag.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
-	flag.Var(&logging.verbosity, "v", "log level for V logs")
-	flag.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
-	flag.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
-	flag.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
+	flag.BoolVar(&logging.toStderr, "tt_logtostderr", false, "log to standard error instead of files")
+	flag.BoolVar(&logging.alsoToStderr, "tt_alsologtostderr", false, "log to standard error as well as files")
+	flag.Var(&logging.verbosity, "tt_v", "log level for V logs")
+	flag.Var(&logging.stderrThreshold, "tt_stderrthreshold", "logs at or above this threshold go to stderr")
+	flag.Var(&logging.vmodule, "tt_vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
+	flag.Var(&logging.traceLocation, "tt_log_backtrace_at", "when logging hits line file:N, emit a stack trace")
 
 	// Default stderrThreshold is ERROR.
 	logging.stderrThreshold = errorLog

--- a/glog_file.go
+++ b/glog_file.go
@@ -38,7 +38,7 @@ var logDirs []string
 
 // If non-empty, overrides the choice of directory in which to write logs.
 // See createLogDirs for the full list of possible destinations.
-var logDir = flag.String("log_dir", "", "If non-empty, write log files in this directory")
+var logDir = flag.String("tt_log_dir", "", "If non-empty, write log files in this directory")
 
 func createLogDirs() {
 	if *logDir != "" {


### PR DESCRIPTION
If teltech/glog and golang/glog are imported to the same binary,
the conflict and cause a panic. I can't figure out how to stop revel
from including golang/glog in the generated app/tmp/main.go file. So,
I prefixed the flags here to fix the panic.

I'm not sure if this is the proper solution, or the best solution.

Edit: This is the error message I get without this fix.
```
% GODEBUG=x509ignoreCN=0 /tmp/konfide/konfide -importPath github.com/teltech/konfide -srcPath /tmp/konfide/src -runMode prod
/tmp/konfide/konfide flag redefined: log_dir
panic: /tmp/konfide/konfide flag redefined: log_dir

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc0000421e0, 0x12668c0, 0xc00007c680, 0x10dcb40, 0x7, 0x1118f93, 0x2f)
        /usr/lib/go/src/flag/flag.go:851 +0x485
flag.(*FlagSet).StringVar(...)
        /usr/lib/go/src/flag/flag.go:754
flag.(*FlagSet).String(0xc0000421e0, 0x10dcb40, 0x7, 0x0, 0x0, 0x1118f93, 0x2f, 0xc00007c670)
        /usr/lib/go/src/flag/flag.go:767 +0xa5
flag.String(0x10dcb40, 0x7, 0x0, 0x0, 0x1118f93, 0x2f, 0xc000090280)
        /usr/lib/go/src/flag/flag.go:774 +0x69
github.com/teltech/glog.init()
        /home/matt/go/src/github.com/teltech/glog/glog_file.go:41 +0xd3
```